### PR TITLE
Ignore build metadata for sort order

### DIFF
--- a/v4/range_test.go
+++ b/v4/range_test.go
@@ -48,30 +48,31 @@ var (
 	v1 = MustParse("1.2.2")
 	v2 = MustParse("1.2.3")
 	v3 = MustParse("1.2.4")
+	v4 = MustParse("1.2.4+ignoreme")
 )
 
 func testEQ(f comparator) bool {
-	return f(v1, v1) && !f(v1, v2)
+	return f(v1, v1) && !f(v1, v2) && f(v3, v4)
 }
 
 func testNE(f comparator) bool {
-	return !f(v1, v1) && f(v1, v2)
+	return !f(v1, v1) && f(v1, v2) && !f(v3, v4)
 }
 
 func testGT(f comparator) bool {
-	return f(v2, v1) && f(v3, v2) && !f(v1, v2) && !f(v1, v1)
+	return f(v2, v1) && f(v3, v2) && !f(v1, v2) && !f(v1, v1) && !f(v3, v4)
 }
 
 func testGE(f comparator) bool {
-	return f(v2, v1) && f(v3, v2) && !f(v1, v2)
+	return f(v2, v1) && f(v3, v2) && !f(v1, v2) && f(v3, v4)
 }
 
 func testLT(f comparator) bool {
-	return f(v1, v2) && f(v2, v3) && !f(v2, v1) && !f(v1, v1)
+	return f(v1, v2) && f(v2, v3) && !f(v2, v1) && !f(v1, v1) && !f(v3, v4)
 }
 
 func testLE(f comparator) bool {
-	return f(v1, v2) && f(v2, v3) && !f(v2, v1)
+	return f(v1, v2) && f(v2, v3) && !f(v2, v1) && f(v3, v4)
 }
 
 func TestSplitAndTrim(t *testing.T) {
@@ -385,6 +386,7 @@ func TestParseRange(t *testing.T) {
 		{"1.2.3", []tv{
 			{"1.2.2", false},
 			{"1.2.3", true},
+			{"1.2.3+ignoreme", true},
 			{"1.2.4", false},
 		}},
 		{"=1.2.3", []tv{

--- a/v4/semver.go
+++ b/v4/semver.go
@@ -148,11 +148,7 @@ func (v Version) Compare(o Version) int {
 		return -1
 	}
 
-	if comp := v.Pre.Compare(o.Pre); comp != 0 {
-		return comp
-	}
-
-	return v.Build.Compare(o.Build)
+	return v.Pre.Compare(o.Pre)
 }
 
 // IncrementPatch increments the patch version

--- a/v4/semver_test.go
+++ b/v4/semver_test.go
@@ -152,12 +152,12 @@ var compareTests = []compareTest{
 	{Version{1, 0, 0, []versionExtension{extstr("rc"), extnum(1)}, nil}, Version{1, 0, 0, nil, nil}, -1},
 
 	// Ignore Build metadata
-	{Version{1, 0, 0, nil, []versionExtension{extnum(1), extnum(2), extnum(3)}}, Version{1, 0, 0, nil, nil}, 1},
-	{Version{1, 0, 0, nil, []versionExtension{extnum(1), extnum(2), extnum(3)}}, Version{1, 0, 0, nil, []versionExtension{extnum(1), extnum(2)}}, 1},
-	{Version{1, 0, 0, nil, []versionExtension{extstr("a")}}, Version{1, 0, 0, nil, []versionExtension{extnum(1)}}, 1},
+	{Version{1, 0, 0, nil, []versionExtension{extnum(1), extnum(2), extnum(3)}}, Version{1, 0, 0, nil, nil}, 0},
+	{Version{1, 0, 0, nil, []versionExtension{extnum(1), extnum(2), extnum(3)}}, Version{1, 0, 0, nil, []versionExtension{extnum(1), extnum(2)}}, 0},
+	{Version{1, 0, 0, nil, []versionExtension{extstr("a")}}, Version{1, 0, 0, nil, []versionExtension{extnum(1)}}, 0},
 	{Version{1, 0, 0, nil, []versionExtension{extstr("a")}}, Version{1, 0, 0, nil, []versionExtension{extstr("a")}}, 0},
-	{Version{1, 0, 0, nil, []versionExtension{extnum(1)}}, Version{1, 0, 0, nil, []versionExtension{extnum(2)}}, -1},
-	{Version{1, 0, 0, []versionExtension{extnum(2)}, []versionExtension{extnum(2)}}, Version{1, 0, 0, []versionExtension{extnum(3)}, []versionExtension{extnum(1)}}, -1},
+	{Version{1, 0, 0, nil, []versionExtension{extnum(1)}}, Version{1, 0, 0, nil, []versionExtension{extnum(2)}}, 0},
+	{Version{1, 0, 0, []versionExtension{extnum(2)}, []versionExtension{extnum(2)}}, Version{1, 0, 0, []versionExtension{extnum(2)}, []versionExtension{extnum(1)}}, 0},
 }
 
 func TestCompare(t *testing.T) {

--- a/v4/sort.go
+++ b/v4/sort.go
@@ -24,5 +24,5 @@ func (s Versions) Less(i, j int) bool {
 
 // Sort sorts a slice of versions
 func Sort(versions []Version) {
-	sort.Sort(Versions(versions))
+	sort.Stable(Versions(versions))
 }

--- a/v4/sort_test.go
+++ b/v4/sort_test.go
@@ -8,11 +8,13 @@ import (
 func TestSort(t *testing.T) {
 	v100, _ := Parse("1.0.0")
 	v010, _ := Parse("0.1.0")
+	v001b, _ := Parse("0.0.1+b")
 	v001, _ := Parse("0.0.1")
-	versions := []Version{v010, v100, v001}
+	v001a, _ := Parse("0.0.1+a")
+	versions := []Version{v010, v100, v001b, v001, v001a}
 	Sort(versions)
 
-	correct := []Version{v001, v010, v100}
+	correct := []Version{v001b, v001, v001a, v010, v100}
 	if !reflect.DeepEqual(versions, correct) {
 		t.Fatalf("Sort returned wrong order: %s", versions)
 	}
@@ -21,10 +23,12 @@ func TestSort(t *testing.T) {
 func BenchmarkSort(b *testing.B) {
 	v100, _ := Parse("1.0.0")
 	v010, _ := Parse("0.1.0")
+	v001b, _ := Parse("0.0.1+b")
 	v001, _ := Parse("0.0.1")
+	v001a, _ := Parse("0.0.1+a")
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		Sort([]Version{v010, v100, v001})
+		Sort([]Version{v010, v100, v001b, v001, v001a})
 	}
 }


### PR DESCRIPTION
Use sort.Stable for repeatable sorts of semantically-equal versions

Build metadata MUST be ignored when determining version precedence
https://semver.org/spec/v2.0.0.html#spec-item-10

related: https://github.com/carvel-dev/kapp-controller/issues/1338