### PR TITLE
Don't treat x in pre-release and build metadata identifiers as a wild…

### DIFF
--- a/v4/range.go
+++ b/v4/range.go
@@ -327,12 +327,12 @@ func expandWildcardVersion(parts [][]string) ([][]string, error) {
 	for _, p := range parts {
 		var newParts []string
 		for _, ap := range p {
-			if strings.Contains(ap, "x") {
-				opStr, vStr, err := splitComparatorVersion(ap)
-				if err != nil {
-					return nil, err
-				}
+			opStr, vStr, err := splitComparatorVersion(ap)
+			if err != nil {
+				return nil, err
+			}
 
+			if containsWildcard(ap) {
 				versionWildcardType := getWildcardType(vStr)
 				flatVersion := createVersionFromWildcard(vStr)
 
@@ -379,6 +379,16 @@ func expandWildcardVersion(parts [][]string) ([][]string, error) {
 	}
 
 	return expandedParts, nil
+}
+
+// containsWildcard returns true if there's a wildcard in any of the major, minor or patch components
+func containsWildcard(v string) bool {
+	return strings.Contains(trimIdentifiers(v), ".x")
+}
+
+// trimIdentifiers removes any pre-release and build metadata from a version
+func trimIdentifiers(v string) string {
+  return strings.Split(strings.Split(v, "+")[0], "-")[0]
 }
 
 func parseComparator(s string) comparator {

--- a/v4/range_test.go
+++ b/v4/range_test.go
@@ -202,6 +202,7 @@ func TestGetWildcardType(t *testing.T) {
 		{"x", majorWildcard},
 		{"1.x", minorWildcard},
 		{"1.2.x", patchWildcard},
+		{"1.2.3-x", noneWildcard},
 		{"fo.o.b.ar", noneWildcard},
 	}
 
@@ -386,6 +387,19 @@ func TestParseRange(t *testing.T) {
 			{"1.2.2", false},
 			{"1.2.3", true},
 			{"1.2.4", false},
+		}},
+		{"1.2.3-x.x", []tv{
+			{"1.2.3-x.y", false},
+			{"1.2.3-x.x", true},
+		}},
+		{"1.2.3+x.x", []tv{
+			{"1.2.3+x.y", false},
+			{"1.2.3+x.x", true},
+		}},
+		{"1.2.3-x.x+x.x", []tv{
+			{"1.2.3-x.x+x.y", false},
+			{"1.2.3-x.y+x.x", false},
+			{"1.2.3-x.x+x.x", true},
 		}},
 		{"=1.2.3", []tv{
 			{"1.2.2", false},


### PR DESCRIPTION
…card

I don't think we would want to extend logic to wildcards _inside_ pre-release and build metadata identifiers.

Would need flow up through vendir into kapp-controller.

refs:
* https://github.com/carvel-dev/vendir/issues/123
* https://github.com/carvel-dev/kapp-controller/issues/1518

