### PR TITLE
fix: refine stability precedence to support standard prerelease sorting

### DIFF
--- a/v4/semver.go
+++ b/v4/semver.go
@@ -471,20 +471,29 @@ func (v versionExtension) Compare(o versionExtension) int {
 	// 2. Handle Numeric vs Alphanumeric
 	// Identify segments containing pre-release identifiers (rc, alpha, beta).
 	isPreReleaseLabel := func(s string) bool {
-		sl := strings.ToLower(s)
-		return strings.Contains(sl, "rc") || (strings.Contains(sl, "-") &&
-			(strings.Contains(sl, "alpha") || strings.Contains(sl, "beta")))
+		lowerStr := strings.ToLower(s)
+		if !strings.Contains(lowerStr, "-") {
+			return false
+		}
+		// Only flag as pre-release if it contains these specific markers
+		preReleaseMarkers := []string{"alpha", "beta", "rc", "pre", "dev"}
+		for _, marker := range preReleaseMarkers {
+			if strings.Contains(lowerStr, marker) {
+				return true
+			}
+		}
+		return false
 	}
 
 	if v.IsNum && !o.IsNum {
 		if isPreReleaseLabel(o.VersionStr) {
-			return 1 // Stability Priority: Stable > Pre-release
+			return 1 // Number wins against an RC/Alpha/Beta string
 		}
 		return -1 // Standard SemVer: Number < String
 	}
 	if !v.IsNum && o.IsNum {
 		if isPreReleaseLabel(v.VersionStr) {
-			return -1 // Stability Priority: Pre-release < Stable
+			return -1 // RC/Alpha/Beta string loses against a Number
 		}
 		return 1 // Standard SemVer: String > Number
 	}
@@ -492,20 +501,6 @@ func (v versionExtension) Compare(o versionExtension) int {
 	// 3. Both are Alphanumeric
 	if v.VersionStr == o.VersionStr {
 		return 0
-	}
-
-	// Pre-release marker check for string-vs-string
-	isPre := func(s string) bool {
-		sl := strings.ToLower(s)
-		return strings.Contains(sl, "rc") || strings.Contains(sl, "alpha") || strings.Contains(sl, "beta")
-	}
-
-	preV, preO := isPre(v.VersionStr), isPre(o.VersionStr)
-	if preV != preO {
-		if preV {
-			return -1
-		}
-		return 1
 	}
 
 	// Natural sort fallback for generic segments (e.g. "9-fips" vs "10-fips")

--- a/v4/semver_test.go
+++ b/v4/semver_test.go
@@ -597,6 +597,18 @@ func TestEdgeCases_NaturalSortAndMetadata(t *testing.T) {
 
 		// 3. Mixed Alphanumeric: abc2 should be less than abc10
 		{"1.0.0+abc2", "1.0.0+abc10", -1, "Natural sort: abc2 should be less than abc10"},
+
+		// 4. Vendir Compatibility (The new case pre < rc)
+		{"0.0.1-pre.1", "0.0.1-rc.0", -1, "Vendir: pre < rc alphabetically"},
+
+		// 5. Standard Pre release numeric ones
+		{"1.0.0-rc.1", "1.0.0-rc.2", -1, "Standard: numeric pre-release"},
+
+		// 6. Stability Check: Ensure alpha/beta without hyphens follow standard rules
+		{"1.0.0-beta", "1.0.0-rc", -1, "Standard: beta < rc alphabetically as segments have no internal hyphens"},
+
+		// 7. Stable release vs higher FIPS release
+		{"1.2.3+abc.9", "1.2.3+abc.10-fips", -1, "Standard: 9 should be less than 10-fips"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Refinement of Metadata Precedence Logic**
This follow-up PR adjusts the build metadata comparison logic to ensure stability-aware precedence (GA > RC) only applies when comparing numeric segments to alphanumeric ones.

**Verified Improvements:**
**Natural Sorting:** vmware.10-fips now correctly ranks higher than vmware.9-fips.

**Stability:** 3.4.0+v1.33 (Stable) now correctly ranks higher than 3.4.0+v1.33-rc.2.

**Compatibility:** Standard pre-release ordering (e.g., 0.0.1-pre.1 < 0.0.1-rc.0) is preserved, fixing a regression found in vendir.

**Validation :** 
All 38+ existing unit tests, alongside new edge-case coverage Passed ✅
```
Current changeset Validation : 
➜  v4 git:(topic/sameerforge/follow-up-semver-fix) go test -v .                                                        
=== RUN   TestJSONMarshal
--- PASS: TestJSONMarshal (0.00s)
=== RUN   TestJSONUnmarshal
--- PASS: TestJSONUnmarshal (0.00s)
=== RUN   TestParseComparator
--- PASS: TestParseComparator (0.00s)
=== RUN   TestSplitAndTrim
--- PASS: TestSplitAndTrim (0.00s)
=== RUN   TestSplitComparatorVersion
--- PASS: TestSplitComparatorVersion (0.00s)
=== RUN   TestBuildVersionRange
--- PASS: TestBuildVersionRange (0.00s)
=== RUN   TestSplitORParts
--- PASS: TestSplitORParts (0.00s)
=== RUN   TestGetWildcardType
--- PASS: TestGetWildcardType (0.00s)
=== RUN   TestCreateVersionFromWildcard
--- PASS: TestCreateVersionFromWildcard (0.00s)
=== RUN   TestIncrementMajorVersion
--- PASS: TestIncrementMajorVersion (0.00s)
=== RUN   TestIncrementMinorVersion
--- PASS: TestIncrementMinorVersion (0.00s)
=== RUN   TestExpandWildcardVersion
--- PASS: TestExpandWildcardVersion (0.00s)
=== RUN   TestVersionRangeToRange
--- PASS: TestVersionRangeToRange (0.00s)
=== RUN   TestRangeAND
--- PASS: TestRangeAND (0.00s)
=== RUN   TestRangeOR
--- PASS: TestRangeOR (0.00s)
=== RUN   TestParseRange
--- PASS: TestParseRange (0.00s)
=== RUN   TestMustParseRange
--- PASS: TestMustParseRange (0.00s)
=== RUN   TestMustParseRange_panic
--- PASS: TestMustParseRange_panic (0.00s)
=== RUN   TestStringer
--- PASS: TestStringer (0.00s)
=== RUN   TestParse
--- PASS: TestParse (0.00s)
=== RUN   TestParseTolerant
--- PASS: TestParseTolerant (0.00s)
=== RUN   TestMustParse
--- PASS: TestMustParse (0.00s)
=== RUN   TestMustParse_panic
--- PASS: TestMustParse_panic (0.00s)
=== RUN   TestValidate
--- PASS: TestValidate (0.00s)
=== RUN   TestFinalizeVersionMethod
--- PASS: TestFinalizeVersionMethod (0.00s)
=== RUN   TestCompare
--- PASS: TestCompare (0.00s)
=== RUN   TestWrongFormat
--- PASS: TestWrongFormat (0.00s)
=== RUN   TestWrongTolerantFormat
--- PASS: TestWrongTolerantFormat (0.00s)
=== RUN   TestCompareHelper
--- PASS: TestCompareHelper (0.00s)
=== RUN   TestIncrements
--- PASS: TestIncrements (0.00s)
=== RUN   TestPreReleaseVersions
--- PASS: TestPreReleaseVersions (0.00s)
=== RUN   TestBuildMetaDataVersions
--- PASS: TestBuildMetaDataVersions (0.00s)
=== RUN   TestNewHelper
--- PASS: TestNewHelper (0.00s)
=== RUN   TestMakeHelper
--- PASS: TestMakeHelper (0.00s)
=== RUN   TestFinalizeVersion
--- PASS: TestFinalizeVersion (0.00s)
=== RUN   TestEdgeCases_NaturalSortAndMetadata
--- PASS: TestEdgeCases_NaturalSortAndMetadata (0.00s)
=== RUN   TestSort
--- PASS: TestSort (0.00s)
=== RUN   TestScanString
--- PASS: TestScanString (0.00s)
PASS
ok      github.com/carvel-dev/semver/v4 0.502s
```


**Validation with Vendir Test :** 
Tests Passed ✅
```
➜  vendir git:(develop) ✗ go test -v ./pkg/vendir/versions/                                   

=== RUN   TestSemverOrder
--- PASS: TestSemverOrder (0.00s)
=== RUN   TestSemverFilter
--- PASS: TestSemverFilter (0.00s)
=== RUN   TestSemverWithoutPrereleases
--- PASS: TestSemverWithoutPrereleases (0.00s)
=== RUN   TestSemverWithPrereleases
--- PASS: TestSemverWithPrereleases (0.00s)
=== RUN   TestSemverWithPrereleaseIdentifiers
--- PASS: TestSemverWithPrereleaseIdentifiers (0.00s)
=== RUN   TestSemverWithBuildMetadata
--- PASS: TestSemverWithBuildMetadata (0.00s)
=== RUN   TestSemverWithBuildMetadataAndConstraint
--- PASS: TestSemverWithBuildMetadataAndConstraint (0.00s)
=== RUN   TestHighestVersionWithConstraints
--- PASS: TestHighestVersionWithConstraints (0.00s)
PASS
ok      carvel.dev/vendir/pkg/vendir/versions   (cached)
```